### PR TITLE
Fixes for options.noInteraction

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function(command, opt){
 	if (typeof opt.clear === 'undefined') { opt.clear = false; }
 	if (typeof opt.flags === 'undefined') { opt.flags = ''; }
 	if (typeof opt.notify === 'undefined') { opt.notify = false; }
-	if (typeof opt.noInteraction === 'undefined') { opt.noInteraction = true; }
+	if (typeof opt.noInteract === 'undefined') { opt.noInteract = false; }
 	if (typeof opt.noAnsi === 'undefined') { opt.noAnsi = false; }
 	if (typeof opt.quiet === 'undefined') { opt.quiet = false; }
 
@@ -49,7 +49,7 @@ module.exports = function(command, opt){
 		if (opt.testClass) { cmd += ' ' + opt.testClass; }
 		if (opt.verbose) { cmd += ' -' + opt.verbose; }
 		if (opt.quiet) { cmd += ' --quiet'; }
-		if ( ! opt.noInteraction) { cmd += ' --no-interaction'; }
+		if (opt.noInteract) { cmd += ' --no-interaction'; }
 		cmd += opt.noAnsi ? ' --no-ansi' : ' --ansi';
 
 		if(counter === 0) {


### PR DESCRIPTION
The documentation for specifying that phpspec run in non-interactive mode reads that the option name is `options.noInteract` while the current codebase actually uses `opt.noInteraction`.  This PR changes the variable name to match documentation. 

In addition, the default for this option is specified as `false` in the documentation, yet is set to `true` in source.  The source has been updated to match this.  Also, when the module is building up the command to run, the conditional statement was checking the opposite of what would be expected.  In the current source, to make `gulp-phpspec` run my specs in non-interactive mode, I must specify options like:

``` js
gulp.task('phpspec', function() {
    var options = {
        debug: true,
        clear: true,
        noInteraction: false  // This is awkward?
    };

    gulp.src('tests/spec/**/*.php')
        .pipe(phpspec('', options))
        .on('error', notify.onError({
            title: "Testing Failed",
            message: "Error(s) occurred during test..."
        }));
});
```

Anywho, just wanted to drop these updates quickly.  Please let me know if you would rather keep the longer variable name in source and instead update documentation.  Either way, I think updating the boolean check when building the command is a good idea... but will be a breaking change (which I think is justifiable before a 1.0 release). 

Thanks for the work! Love this module!
